### PR TITLE
Fixing missing reference to Group

### DIFF
--- a/lib/Message.js
+++ b/lib/Message.js
@@ -1,8 +1,9 @@
 'use strict';
 
-let User     = require('./User');
+let Group    = require('./Group');
 let Priority = require('./Priority');
 let Sound    = require('./Sound');
+let User     = require('./User');
 
 const DEFAULT_PROPERTIES = {
   message:    null,


### PR DESCRIPTION
`Message.js` was missing a reference to `Group`. This made it impossible to send group messages.